### PR TITLE
Adjust grid layout and sidebar order for mobile draft interface

### DIFF
--- a/src/components/DraftInterface.css
+++ b/src/components/DraftInterface.css
@@ -218,11 +218,10 @@ button:disabled {
 @media (max-width: 1024px) {
   .draft-interface {
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: 1fr auto;
   }
   
   .deck-sidebar {
-    order: -1;
     max-height: 200px;
     padding: 15px;
   }


### PR DESCRIPTION
## Summary
- Updates the CSS grid layout for the draft interface on screens smaller than 1024px
- Changes the grid-template-rows order to prioritize main content over sidebar
- Removes the negative order from the deck sidebar to adjust its position

## Changes

### CSS Updates
- Modified `.draft-interface` grid-template-rows from `auto 1fr` to `1fr auto` for better layout on mobile
- Removed `order: -1` from `.deck-sidebar` to change sidebar stacking order

## Test plan
- [ ] Verify the draft interface layout on screens smaller than 1024px
- [ ] Confirm the main content appears above the sidebar
- [ ] Ensure the sidebar no longer uses negative order and displays correctly
- [ ] Check for any layout regressions on larger screens

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/55d36881-b5ee-4190-a2db-59822ea6af83